### PR TITLE
Added support for Huawei/Vodafone K5161h USB modem

### DIFF
--- a/tesla-android-usb-networking-initialiser.c
+++ b/tesla-android-usb-networking-initialiser.c
@@ -18,7 +18,7 @@ char* alcatelIK40VInitialisationCommand = "/vendor/bin/usb_modeswitch -c /vendor
 char* huaweiVendorId = "12d1";
 char* huaweiInitialisationCommand = "/vendor/bin/usb_modeswitch -c /vendor/tesla-android/usb_modeswitch/12d1.conf";
 
-char* vodafoneK5161h = "12d1:1f1d";
+char* vodafoneK5161hId = "12d1:1f1d";
 char* vodafoneK5161hInitialisationCommand = "/vendor/bin/usb_modeswitch -c /vendor/tesla-android/usb_modeswitch/12d1-1f1d.conf";
 
 // https://www.draisberghof.de/usb_modeswitch/bb/viewtopic.php?f=3&t=3043&p=20026#p20054
@@ -59,7 +59,7 @@ void initialiseDevice(char * deviceId) {
 	} else if(strstr(deviceId, alcatelIK40VId)) {
 		printf("Initialising Alcatel IK40V");
 		system(alcatelIK40VInitialisationCommand);
-	} else if(strstr(deviceId, vodafoneK5161h)) {
+	} else if(strstr(deviceId, vodafoneK5161hId)) {
 		printf("Initialising Vodafone device");
 		system(vodafoneK5161hInitialisationCommand);
 	} else if(strstr(deviceId, huaweiVendorId)) {

--- a/tesla-android-usb-networking-initialiser.c
+++ b/tesla-android-usb-networking-initialiser.c
@@ -18,6 +18,9 @@ char* alcatelIK40VInitialisationCommand = "/vendor/bin/usb_modeswitch -c /vendor
 char* huaweiVendorId = "12d1";
 char* huaweiInitialisationCommand = "/vendor/bin/usb_modeswitch -c /vendor/tesla-android/usb_modeswitch/12d1.conf";
 
+char* vodafoneK5161h = "12d1:1f1d";
+char* vodafoneK5161hInitialisationCommand = "/vendor/bin/usb_modeswitch -c /vendor/tesla-android/usb_modeswitch/12d1-1f1d.conf";
+
 // https://www.draisberghof.de/usb_modeswitch/bb/viewtopic.php?f=3&t=3043&p=20026#p20054
 char* huawei_E3372_325Id = "3566:2001";
 char* huawei_E3372_325InitialisationCommand1 = "/vendor/bin/usb_modeswitch -v 3566 -p 2001 -W -R -w 400";
@@ -56,6 +59,9 @@ void initialiseDevice(char * deviceId) {
 	} else if(strstr(deviceId, alcatelIK40VId)) {
 		printf("Initialising Alcatel IK40V");
 		system(alcatelIK40VInitialisationCommand);
+	} else if(strstr(deviceId, vodafoneK5161h)) {
+		printf("Initialising Vodafone device");
+		system(vodafoneK5161hInitialisationCommand);
 	} else if(strstr(deviceId, huaweiVendorId)) {
 		printf("Initialising Huawei device");
 		system(huaweiInitialisationCommand);


### PR DESCRIPTION
12d1-1f1d.conf file created in [tesla-android/android-vendor-tesla-android](https://github.com/tesla-android/android-vendor-tesla-android/blob/main/services/usb_modeswitch) repo.

Put it before `huaweiVendorId` in the if/elseif block because it's a more specific combination of vendorid+productid